### PR TITLE
Correctly detecting compiled java files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /deps/releases
 /deps/gbe-linux
 /deps/gbe-win
-/deps/gamescope
 /deps/umu
 res/gamescope
 gen_release.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /deps/releases
 /deps/gbe-linux
 /deps/gbe-win
+/deps/gamescope
 /deps/umu
 res/gamescope
 gen_release.sh

--- a/build.rs
+++ b/build.rs
@@ -81,11 +81,29 @@ macro_rules! build_println {
 
 #[allow(dead_code)]
 fn apply_patches(deps_dir: &std::path::Path) {
-    let mut git_apply = std::process::Command::new("git");
-    git_apply.args(["apply", &deps_dir.join("deps.patch").to_string_lossy()]);
-    let _ = git_apply.spawn().map_err(|e| {
-        build_println!("Failed to git apply the patches we have for our deps, this is most likely not a real error: {:?} - {:?}", git_apply.get_program().to_string_lossy(), e);
-    });
+    let patch_path = deps_dir.join("deps.patch");
+
+    // Check if the patch can be applied before attempting it.
+    // If the check fails the patch is most likely already applied, so skip silently.
+    let check = std::process::Command::new("git")
+        .args(["apply", "--check", &patch_path.to_string_lossy()])
+        .output();
+
+    match check {
+        Ok(output) if output.status.success() => {
+            let status = std::process::Command::new("git")
+                .args(["apply", &patch_path.to_string_lossy()])
+                .status();
+            match status {
+                Ok(s) if s.success() => { build_println!("Applied patches from deps.patch"); }
+                Ok(s) => { build_println!("git apply exited with {s} for deps.patch"); }
+                Err(e) => { build_println!("Failed to run git apply: {e}"); }
+            }
+        }
+        _ => {
+            build_println!("Skipping deps.patch (already applied or does not apply cleanly)");
+        }
+    }
 }
 
 fn main() {
@@ -135,7 +153,7 @@ fn build_gamescope(deps_dir: &Path, target_dir: &PathBuf) {
     let gamescope_dir = deps_dir.join("gamescope");
     let build_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("gamescope-build-gcc");
 
-    if !build_dir.exists() && gamescope_dir.exists() {
+    if !build_dir.join("build.ninja").exists() && gamescope_dir.exists() {
         build_println!("Running meson setup command for gamescope");
         let status = Command::new("meson")
             .arg("setup")

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -18,6 +18,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_kbm_support() -> bool {
+    pathsearch::find_executable_in_path("gamescope-kbm").is_some()
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct PartyConfig {
     #[serde(default = "default_true")]
@@ -28,7 +32,7 @@ pub struct PartyConfig {
     pub gamescope_sdl_backend: bool,
     #[serde(default)]
     pub gamescope_force_grab_cursor: bool,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_kbm_support")]
     pub kbm_support: bool,
     #[serde(default)]
     pub proton_version: String,
@@ -57,7 +61,7 @@ impl Default for PartyConfig {
             gamescope_fix_lowres: true,
             gamescope_sdl_backend: true,
             gamescope_force_grab_cursor: false,
-            kbm_support: true,
+            kbm_support: pathsearch::find_executable_in_path("gamescope-kbm").is_some(),
             proton_version: "".to_string(),
             proton_separate_pfxs: true,
             proton_wow64: true,

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -358,6 +358,9 @@ pub fn launch_cmds(
         }
 
 
+        if path_exec.extension().map_or(false, |ext| ext == "jar") {
+            cmd.args(["java", "-jar"]);
+        }
         cmd.arg(&path_exec);
 
         for arg in h.args.split_whitespace() {

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -357,10 +357,6 @@ pub fn launch_cmds(
             };
         }
 
-
-        if path_exec.extension().map_or(false, |ext| ext == "jar") {
-            cmd.args(["java", "-jar"]);
-        }
         cmd.arg(&path_exec);
 
         for arg in h.args.split_whitespace() {


### PR DESCRIPTION
The `.jar` file is being executed directly as a shell script instead of being run with `java -jar`. The system is trying to execute the JAR file as if it were a shell script.

When launch.rs detects a `.jar` file as the executable, it should prepend `java -jar` to the command.

Linked to #179

This PR successfully solves two issues:
- Java games like Necesse not even opening
- Very specific build error with `git apply` that I was facing

Now partydeck can open the Necesse game, but setting up windows for two controllers/players is not working properly; and I don't have any idea why and how to keep going from here.