### PR TITLE
Add virtual gamepads for controller reconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,6 +2704,7 @@ dependencies = [
  "evdev",
  "fastrand",
  "image",
+ "nix 0.29.0",
  "pathsearch",
  "reqwest",
  "rfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ zbus = { version = "5.5.0", features = ["async-io", "blocking-api"], default-fea
 steamlocate = "2.0.1"
 zip = { version = "5.1.1", features = ["deflate", "deflate64"], default-features = false }
 pathsearch = "0.2.0"
+nix = { version = "0.29", features = ["poll"] }
 
 [build-dependencies]
 reqwest = { version = "0.12.15", features = ["blocking", "json"], optional = true }

--- a/src/app/app_pages.rs
+++ b/src/app/app_pages.rs
@@ -639,6 +639,10 @@ impl PartyApp {
             &mut self.options.kbm_support,
             "Enable keyboard and mouse support through custom Gamescope",
         );
+        let virtual_gamepads_check = ui.checkbox(
+            &mut self.options.use_virtual_gamepads,
+            "Preserve controller bindings on reconnect (Experimental)",
+        );
         let gamescope_force_grab_cursor_check = ui.checkbox(
             &mut self.options.gamescope_force_grab_cursor,
             "Force grab cursor for Gamescope",
@@ -652,6 +656,9 @@ impl PartyApp {
         }
         if kbm_support_check.hovered() {
             self.infotext = "Runs a custom Gamescope build with support for holding keyboards and mice. If you want to use your own Gamescope installation, uncheck this.".to_string();
+        }
+        if virtual_gamepads_check.hovered() {
+            self.infotext = "Routes assigned gamepads through persistent virtual controllers, game instances keep their controller after reconnects. Gamepads only.".to_string();
         }
         if gamescope_force_grab_cursor_check.hovered() {
             self.infotext = "Sets the \"--force-grab-cursor\" flag in Gamescope. This keeps the cursor within the Gamescope window. If unsure, leave this unchecked.".to_string();

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -31,6 +31,8 @@ pub struct PartyConfig {
     #[serde(default = "default_true")]
     pub kbm_support: bool,
     #[serde(default)]
+    pub use_virtual_gamepads: bool,
+    #[serde(default)]
     pub proton_version: String,
     #[serde(default = "default_true")]
     pub proton_separate_pfxs: bool,
@@ -58,6 +60,7 @@ impl Default for PartyConfig {
             gamescope_sdl_backend: true,
             gamescope_force_grab_cursor: false,
             kbm_support: true,
+            use_virtual_gamepads: false,
             proton_version: "".to_string(),
             proton_separate_pfxs: true,
             proton_wow64: true,

--- a/src/input.rs
+++ b/src/input.rs
@@ -142,6 +142,9 @@ impl InputDevice {
 pub fn scan_input_devices(filter: &PadFilterType) -> Vec<InputDevice> {
     let mut pads: Vec<InputDevice> = Vec::new();
     for dev in evdev::enumerate() {
+        if crate::virtual_gamepad::is_partydeck_virtual_device(&dev.1) {
+            continue;
+        }
         let enabled = match filter {
             PadFilterType::All => true,
             PadFilterType::NoSteamInput => dev.1.input_id().vendor() != 0x28de,

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,13 +1,14 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::app::{PartyConfig, PadFilterType};
+use crate::app::{PadFilterType, PartyConfig};
 use crate::handler::*;
 use crate::input::*;
 use crate::instance::*;
 use crate::paths::*;
 use crate::profiles::{create_profile, create_profile_gamesave};
 use crate::util::*;
+use crate::virtual_gamepad::VirtualGamepadSession;
 
 pub fn setup_profiles(
     h: &Handler,
@@ -36,7 +37,18 @@ pub fn launch_game(
     instances: &Vec<Instance>,
     cfg: &PartyConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let new_cmds = launch_cmds(h, input_devices, instances, cfg)?;
+    let virtual_gamepad_session = VirtualGamepadSession::start_if_enabled(
+        cfg.use_virtual_gamepads,
+        input_devices,
+        instances,
+    )?;
+    let new_cmds = launch_cmds(
+        h,
+        input_devices,
+        instances,
+        cfg,
+        virtual_gamepad_session.as_ref(),
+    )?;
     print_launch_cmds(&new_cmds);
 
     if cfg.enable_kwin_script {
@@ -45,7 +57,8 @@ pub fn launch_game(
             false => "splitscreen_kwin.js",
         };
 
-        kwin_dbus_start_script(PATH_RES.join(script)).map_err(|e| format!("Failed to start KWin script: {}", e))?;
+        kwin_dbus_start_script(PATH_RES.join(script))
+            .map_err(|e| format!("Failed to start KWin script: {}", e))?;
     }
 
     let sleep_time = match h.pause_between_starts {
@@ -58,7 +71,11 @@ pub fn launch_game(
     let mut i = 0;
     for mut cmd in new_cmds {
         let handle = cmd.spawn().map_err(|e| {
-            format!("Failed to start '{}': {}", cmd.get_program().to_string_lossy(), e)
+            format!(
+                "Failed to start '{}': {}",
+                cmd.get_program().to_string_lossy(),
+                e
+            )
         })?;
         handles.push(handle);
 
@@ -80,6 +97,7 @@ pub fn launch_cmds(
     input_devices: &[DeviceInfo],
     instances: &Vec<Instance>,
     cfg: &PartyConfig,
+    virtual_gamepads: Option<&VirtualGamepadSession>,
 ) -> Result<Vec<std::process::Command>, Box<dyn std::error::Error>> {
     let win = h.win();
     let exec = Path::new(&h.exec);
@@ -90,7 +108,9 @@ pub fn launch_cmds(
     };
 
     if cfg.kbm_support && !gamescope.exists() {
-        return Err("gamescope-kbm is missing. Please reinstall partydeck or disable KBM support.".into());
+        return Err(
+            "gamescope-kbm is missing. Please reinstall partydeck or disable KBM support.".into(),
+        );
     }
 
     if !cfg.kbm_support && pathsearch::find_executable_in_path("gamescope").is_none() {
@@ -103,10 +123,16 @@ pub fn launch_cmds(
                 .join("steam/steamapps/common/SteamLinuxRuntime_soldier")
                 .exists())
         || (runtime == "sniper"
-            && !PATH_STEAM.join("steam/steamapps/common/SteamLinuxRuntime_sniper").exists()
-            && !PATH_STEAM.join("steam/steamapps/common/SteamLinuxRuntime_sniper-arm64").exists())
+            && !PATH_STEAM
+                .join("steam/steamapps/common/SteamLinuxRuntime_sniper")
+                .exists()
+            && !PATH_STEAM
+                .join("steam/steamapps/common/SteamLinuxRuntime_sniper-arm64")
+                .exists())
         || (runtime == "steamrt4"
-            && !PATH_STEAM.join("steam/steamapps/common/SteamLinuxRuntime_4").exists())
+            && !PATH_STEAM
+                .join("steam/steamapps/common/SteamLinuxRuntime_4")
+                .exists())
     {
         return Err(format!("Steam Runtime {runtime} not found! Runtime must be installed on the same drive that the Steam client is installed on.").into());
     }
@@ -116,11 +142,12 @@ pub fn launch_cmds(
         .collect();
 
     for (i, instance) in instances.iter().enumerate() {
-        let gamedir = if h.is_saved_handler() && !cfg.disable_mount_gamedirs && cfg.profile_unique_dirs {
-            PATH_PARTY.join("tmp").join(format!("game-{}", i))
-        } else {
-            PathBuf::from(h.get_game_rootpath()?)
-        };
+        let gamedir =
+            if h.is_saved_handler() && !cfg.disable_mount_gamedirs && cfg.profile_unique_dirs {
+                PATH_PARTY.join("tmp").join(format!("game-{}", i))
+            } else {
+                PathBuf::from(h.get_game_rootpath()?)
+            };
 
         if !gamedir.join(exec).exists() {
             return Err(format!("Executable not found: {}", gamedir.join(exec).display()).into());
@@ -177,7 +204,10 @@ pub fn launch_cmds(
             cmd.env("SDL_GAMECONTROLLER_ALLOW_STEAM_VIRTUAL_GAMEPAD", "1");
         }
         if cfg.pad_filter_type == PadFilterType::OnlySteamInput {
-            cmd.env("SDL_GAMECONTROLLER_IGNORE_DEVICES", SDL_GAMECONTROLLER_IGNORE_DEVICES);
+            cmd.env(
+                "SDL_GAMECONTROLLER_IGNORE_DEVICES",
+                SDL_GAMECONTROLLER_IGNORE_DEVICES,
+            );
         }
         if !h.env.is_empty() {
             for env_var in h.env.split_whitespace() {
@@ -239,23 +269,41 @@ pub fn launch_cmds(
         cmd.arg("--die-with-parent");
         cmd.args(["--dev-bind", "/", "/"]);
         cmd.args(["--tmpfs", "/tmp"]);
-        // Mask out any gamepads that aren't this player's
-        for (d, dev) in input_devices.iter().enumerate() {
-            if !dev.enabled
-                || (!instance.devices.contains(&d) && dev.device_type == DeviceType::Gamepad)
-            {
-                cmd.args(["--bind", "/dev/null", &dev.path]);
-                // Wine's winebus reads controllers via /dev/hidraw* when
-                // hidraw is exposed, so masking only the evdev node leaks
-                // input to every instance.
-                if h.enable_hidraw {
-                    for hp in &dev.hidraw_paths {
-                        cmd.args(["--bind", "/dev/null", hp]);
+
+        // Configure input visibility inside the game instance.
+        if let Some(session) = virtual_gamepads {
+            cmd.args(["--tmpfs", "/dev/input"]);
+
+            for device in input_devices {
+                if !device.enabled {
+                    continue;
+                }
+
+                if matches!(device.device_type, DeviceType::Keyboard | DeviceType::Mouse) {
+                    cmd.args(["--dev-bind", &device.path, &device.path]);
+                }
+            }
+
+            for virtual_path in session.gamepads_for_instance(i) {
+                cmd.args(["--dev-bind", virtual_path, virtual_path]);
+            }
+
+            cmd.env("PROTON_DISABLE_HIDRAW", "1");
+        } else {
+            for (d, dev) in input_devices.iter().enumerate() {
+                if !dev.enabled
+                    || (!instance.devices.contains(&d) && dev.device_type == DeviceType::Gamepad)
+                {
+                    cmd.args(["--bind", "/dev/null", &dev.path]);
+
+                    if h.enable_hidraw {
+                        for hp in &dev.hidraw_paths {
+                            cmd.args(["--bind", "/dev/null", hp]);
+                        }
                     }
                 }
             }
         }
-
         if cfg.profile_unique_dirs {
             if win {
                 let path_pfx_user = path_pfx.join("drive_c/users/steamuser");
@@ -292,7 +340,7 @@ pub fn launch_cmds(
         if is_appimage {
             // Because we are faking temp directory, this makes the system use the real vulkan directory for games
             // Used here because the env var is set durring bwrap and gamescope process starting so env cant be cleared at this stage.
-            cmd.args(["--unsetenv","VK_DRIVER_FILES"]); 
+            cmd.args(["--unsetenv", "VK_DRIVER_FILES"]);
         }
 
         if h.use_goldberg {
@@ -307,18 +355,16 @@ pub fn launch_cmds(
                 cmd.env("SteamGameId", &appid.to_string());
             }
 
-            let sdk32_link = std::fs::read_link(PATH_STEAM.join("sdk32")).map_err(|e| format!("Failed to read sdk32 link: {}", e))?;
-            let sdk64_link = std::fs::read_link(PATH_STEAM.join("sdk64")).map_err(|e| format!("Failed to read sdk64 link: {}", e))?;
+            let sdk32_link = std::fs::read_link(PATH_STEAM.join("sdk32"))
+                .map_err(|e| format!("Failed to read sdk32 link: {}", e))?;
+            let sdk64_link = std::fs::read_link(PATH_STEAM.join("sdk64"))
+                .map_err(|e| format!("Failed to read sdk64 link: {}", e))?;
 
-            cmd.arg("--bind").args([
-                PATH_RES.join("goldberg/linux32"),
-                sdk32_link,
-            ]);
+            cmd.arg("--bind")
+                .args([PATH_RES.join("goldberg/linux32"), sdk32_link]);
 
-            cmd.arg("--bind").args([
-                PATH_RES.join("goldberg/linux64"),
-                sdk64_link,
-            ]);
+            cmd.arg("--bind")
+                .args([PATH_RES.join("goldberg/linux64"), sdk64_link]);
 
             if win {
                 cmd.arg("--bind").args([
@@ -345,9 +391,8 @@ pub fn launch_cmds(
                     cmd.arg("--");
                 }
                 "sniper" => {
-                    let sniper_path = PATH_STEAM.join(
-                        "steam/steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point",
-                    );
+                    let sniper_path = PATH_STEAM
+                        .join("steam/steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point");
                     // old installations of sniper go in a folder named -arm64 even though it is x86_64?
                     let sniper_arm_path = PATH_STEAM.join(
                         "steam/steamapps/common/SteamLinuxRuntime_sniper-arm64/_v2-entry-point",
@@ -361,16 +406,14 @@ pub fn launch_cmds(
                 }
                 "steamrt4" => {
                     cmd.arg(
-                        PATH_STEAM.join(
-                            "steam/steamapps/common/SteamLinuxRuntime_4/_v2-entry-point",
-                        ),
+                        PATH_STEAM
+                            .join("steam/steamapps/common/SteamLinuxRuntime_4/_v2-entry-point"),
                     );
                     cmd.arg("--");
                 }
                 _ => {}
             };
         }
-
 
         cmd.arg(&path_exec);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod monitor;
 mod paths;
 mod profiles;
 mod util;
+mod virtual_gamepad;
 
 use crate::app::*;
 use crate::handler::Handler;

--- a/src/virtual_gamepad.rs
+++ b/src/virtual_gamepad.rs
@@ -3,20 +3,22 @@ use crate::{
     instance::Instance,
 };
 
-use evdev::{Device, EventType, InputEvent, UinputAbsSetup, uinput::VirtualDevice};
+use evdev::{uinput::VirtualDevice, Device, EventType, InputEvent, UinputAbsSetup};
 
+use nix::{
+    errno::Errno,
+    poll::{poll, PollFd, PollFlags, PollTimeout},
+};
 use std::{
     io::ErrorKind,
+    net::Shutdown,
+    os::{fd::AsFd, unix::net::UnixStream},
     path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
     thread::{self, JoinHandle},
-    time::Duration,
 };
 
 pub const VIRTUAL_GAMEPAD_NAME_PREFIX: &str = "PartyDeck Internal Virtual Gamepad";
+const RECONNECT_RETRY_MS: u16 = 500;
 
 pub fn is_partydeck_virtual_device(device: &Device) -> bool {
     device
@@ -25,14 +27,15 @@ pub fn is_partydeck_virtual_device(device: &Device) -> bool {
 }
 
 struct VirtualGamepad {
-    path: String,
-    stop: Arc<AtomicBool>,
+    event_path: String,
+    stop_signal: UnixStream,
     thread: Option<JoinHandle<()>>,
 }
 
 impl Drop for VirtualGamepad {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
+        // Wake the relay thread if it is blocked inside poll().
+        let _ = self.stop_signal.shutdown(Shutdown::Write);
 
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
@@ -81,7 +84,7 @@ impl VirtualGamepadSession {
                 println!(
                     "[partydeck] Created virtual gamepad for instance {}: {}",
                     instance_index + 1,
-                    virtual_gamepad.path
+                    virtual_gamepad.event_path
                 );
 
                 gamepads.push(virtual_gamepad);
@@ -107,16 +110,16 @@ impl VirtualGamepadSession {
             .get(instance_index)
             .into_iter()
             .flatten()
-            .map(|gamepad| gamepad.path.as_str())
+            .map(|gamepad| gamepad.event_path.as_str())
     }
 }
 
 fn create_virtual_gamepad(
-    physical_path: &str,
+    physical_event_path: &str,
     instance_index: usize,
     gamepad_index: usize,
 ) -> Result<VirtualGamepad, Box<dyn std::error::Error>> {
-    let physical = Device::open(physical_path)?;
+    let physical = open_nonblocking_device(physical_event_path)?;
 
     let name = format!(
         "{} {}-{}",
@@ -139,119 +142,215 @@ fn create_virtual_gamepad(
     }
 
     let mut virtual_device = builder.build()?;
-    let virtual_path = find_event_path(&mut virtual_device)?;
+    let virtual_event_path = find_event_path(&mut virtual_device)?;
 
-    let physical_path = physical_path.to_owned();
-    let stop = Arc::new(AtomicBool::new(false));
-    let thread_stop = Arc::clone(&stop);
+    let physical_event_path = physical_event_path.to_owned();
+    let (stop_signal, thread_stop_signal) = UnixStream::pair()?;
 
-    let thread = thread::spawn(move || {
-        relay_loop(physical_path, physical, virtual_device, thread_stop);
-    });
+    let thread_name = format!(
+        "partydeck-gamepad-relay-{}-{}",
+        instance_index + 1,
+        gamepad_index + 1
+    );
+
+    let thread = thread::Builder::new().name(thread_name).spawn(move || {
+        relay_loop(
+            physical_event_path,
+            physical,
+            virtual_device,
+            thread_stop_signal,
+        );
+    })?;
 
     Ok(VirtualGamepad {
-        path: virtual_path,
-        stop,
+        event_path: virtual_event_path,
+        stop_signal,
         thread: Some(thread),
     })
 }
+enum RelayPollResult {
+    Stop,
+    InputReady,
+    Disconnected,
+}
+
+fn wait_for_input_or_stop(
+    device: &Device,
+    stop_signal: &UnixStream,
+) -> Result<RelayPollResult, Errno> {
+    loop {
+        let mut fds = [
+            PollFd::new(stop_signal.as_fd(), PollFlags::POLLIN),
+            PollFd::new(device.as_fd(), PollFlags::POLLIN),
+        ];
+
+        match poll(&mut fds, PollTimeout::NONE) {
+            Ok(_) => {}
+            Err(Errno::EINTR) => continue,
+            Err(error) => return Err(error),
+        }
+
+        let stop_events = fds[0].revents().unwrap_or(PollFlags::POLLERR);
+
+        if !stop_events.is_empty() {
+            return Ok(RelayPollResult::Stop);
+        }
+
+        let device_events = fds[1].revents().unwrap_or(PollFlags::POLLERR);
+
+        if device_events.intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL) {
+            return Ok(RelayPollResult::Disconnected);
+        }
+
+        if device_events.contains(PollFlags::POLLIN) {
+            return Ok(RelayPollResult::InputReady);
+        }
+    }
+}
+
+fn wait_for_reconnect_or_stop(stop_signal: &UnixStream) -> Result<bool, Errno> {
+    loop {
+        let mut fds = [PollFd::new(stop_signal.as_fd(), PollFlags::POLLIN)];
+
+        match poll(&mut fds, RECONNECT_RETRY_MS) {
+            Ok(0) => return Ok(false),
+            Ok(_) => return Ok(true),
+            Err(Errno::EINTR) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn open_nonblocking_device(path: &str) -> std::io::Result<Device> {
+    let device = Device::open(path)?;
+    device.set_nonblocking(true)?;
+    Ok(device)
+}
 
 fn relay_loop(
-    physical_path: String,
+    physical_event_path: String,
     physical: Device,
     mut virtual_device: VirtualDevice,
-    stop: Arc<AtomicBool>,
+    stop_signal: UnixStream,
 ) {
-    if let Err(error) = physical.set_nonblocking(true) {
-        eprintln!(
-            "[partydeck] Failed to set gamepad {} to non-blocking mode: {}",
-            physical_path, error
-        );
-        return;
-    }
-
     println!(
         "[partydeck] Started virtual gamepad relay for {}",
-        physical_path
+        physical_event_path
     );
 
     let mut physical_device = Some(physical);
+    let mut events = Vec::<InputEvent>::new();
 
-    while !stop.load(Ordering::Relaxed) {
+    loop {
         if physical_device.is_none() {
-            match Device::open(&physical_path) {
+            match wait_for_reconnect_or_stop(&stop_signal) {
+                Ok(true) => break,
+                Ok(false) => {}
+                Err(error) => {
+                    eprintln!(
+                        "[partydeck] Failed while waiting to reconnect {}: {}",
+                        physical_event_path, error
+                    );
+                    break;
+                }
+            }
+
+            match open_nonblocking_device(&physical_event_path) {
                 Ok(device) => {
-                    if let Err(error) = device.set_nonblocking(true) {
-                        eprintln!(
-                            "[partydeck] Failed to reopen gamepad {}: {}",
-                            physical_path, error
-                        );
-
-                        thread::sleep(Duration::from_millis(500));
-                        continue;
-                    }
-
                     println!(
                         "[partydeck] Physical gamepad reconnected: {}",
-                        physical_path
+                        physical_event_path
                     );
 
                     physical_device = Some(device);
                 }
 
                 Err(_) => {
-                    thread::sleep(Duration::from_millis(500));
-                    continue;
+                    // Retry after another interruptible wait.
                 }
             }
+
+            continue;
         }
+
+        // Block until input, disconnection, or shutdown.
+        let poll_result = {
+            let Some(device) = physical_device.as_ref() else {
+                continue;
+            };
+
+            wait_for_input_or_stop(device, &stop_signal)
+        };
+
+        match poll_result {
+            Ok(RelayPollResult::Stop) => break,
+
+            Ok(RelayPollResult::Disconnected) => {
+                eprintln!(
+                    "[partydeck] Physical gamepad disconnected: {}",
+                    physical_event_path
+                );
+
+                physical_device = None;
+                continue;
+            }
+
+            Ok(RelayPollResult::InputReady) => {}
+
+            Err(error) => {
+                eprintln!(
+                    "[partydeck] Failed to poll physical gamepad {}: {}",
+                    physical_event_path, error
+                );
+                break;
+            }
+        }
+
+        events.clear();
 
         let fetch_result = {
             let Some(device) = physical_device.as_mut() else {
                 continue;
             };
 
-            device.fetch_events().map(|events| {
-                events
-                    .filter(|event| event.event_type() != EventType::SYNCHRONIZATION)
-                    .collect::<Vec<InputEvent>>()
+            device.fetch_events().map(|incoming_events| {
+                events.extend(
+                    incoming_events
+                        .filter(|event| event.event_type() != EventType::SYNCHRONIZATION),
+                );
             })
         };
 
         match fetch_result {
-            Ok(events) => {
-                if events.is_empty() {
-                    thread::sleep(Duration::from_millis(2));
-                    continue;
-                }
+            Ok(()) if events.is_empty() => {}
 
+            Ok(()) => {
                 if let Err(error) = virtual_device.emit(&events) {
                     eprintln!(
                         "[partydeck] Failed to emit virtual gamepad events: {}",
                         error
                     );
+                    break;
                 }
             }
 
-            Err(error) if error.kind() == ErrorKind::WouldBlock => {
-                thread::sleep(Duration::from_millis(2));
-            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {}
 
             Err(error) => {
                 eprintln!(
-                    "[partydeck] Physical gamepad disconnected or failed ({}): {}",
-                    physical_path, error
+                    "[partydeck] Physical gamepad disconnected or failed \
+                     ({}): {}",
+                    physical_event_path, error
                 );
 
                 physical_device = None;
-                thread::sleep(Duration::from_millis(500));
             }
         }
     }
 
     println!(
         "[partydeck] Stopped virtual gamepad relay for {}",
-        physical_path
+        physical_event_path
     );
 }
 

--- a/src/virtual_gamepad.rs
+++ b/src/virtual_gamepad.rs
@@ -9,6 +9,7 @@ use nix::{
     errno::Errno,
     poll::{poll, PollFd, PollFlags, PollTimeout},
 };
+
 use std::{
     io::ErrorKind,
     net::Shutdown,
@@ -17,13 +18,13 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-pub const VIRTUAL_GAMEPAD_NAME_PREFIX: &str = "PartyDeck Internal Virtual Gamepad";
+const VIRTUAL_GAMEPAD_NAME_MARKER: &str = " (PartyDeck ";
 const RECONNECT_RETRY_MS: u16 = 500;
 
 pub fn is_partydeck_virtual_device(device: &Device) -> bool {
     device
         .name()
-        .is_some_and(|name| name.starts_with(VIRTUAL_GAMEPAD_NAME_PREFIX))
+        .is_some_and(|name| name.contains(VIRTUAL_GAMEPAD_NAME_MARKER) && name.ends_with(')'))
 }
 
 struct VirtualGamepad {
@@ -121,9 +122,10 @@ fn create_virtual_gamepad(
 ) -> Result<VirtualGamepad, Box<dyn std::error::Error>> {
     let physical = open_nonblocking_device(physical_event_path)?;
 
+    let physical_name = physical.name().unwrap_or("Gamepad");
     let name = format!(
-        "{} {}-{}",
-        VIRTUAL_GAMEPAD_NAME_PREFIX,
+        "{} (PartyDeck {}-{})",
+        physical_name,
         instance_index + 1,
         gamepad_index + 1
     );
@@ -168,6 +170,7 @@ fn create_virtual_gamepad(
         thread: Some(thread),
     })
 }
+
 enum RelayPollResult {
     Stop,
     InputReady,

--- a/src/virtual_gamepad.rs
+++ b/src/virtual_gamepad.rs
@@ -1,0 +1,273 @@
+use crate::{
+    input::{DeviceInfo, DeviceType},
+    instance::Instance,
+};
+
+use evdev::{Device, EventType, InputEvent, UinputAbsSetup, uinput::VirtualDevice};
+
+use std::{
+    io::ErrorKind,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+pub const VIRTUAL_GAMEPAD_NAME_PREFIX: &str = "PartyDeck Internal Virtual Gamepad";
+
+pub fn is_partydeck_virtual_device(device: &Device) -> bool {
+    device
+        .name()
+        .is_some_and(|name| name.starts_with(VIRTUAL_GAMEPAD_NAME_PREFIX))
+}
+
+struct VirtualGamepad {
+    path: String,
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for VirtualGamepad {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+pub struct VirtualGamepadSession {
+    instance_gamepads: Vec<Vec<VirtualGamepad>>,
+}
+
+impl VirtualGamepadSession {
+    pub fn start_if_enabled(
+        enabled: bool,
+        input_devices: &[DeviceInfo],
+        instances: &[Instance],
+    ) -> Result<Option<Self>, Box<dyn std::error::Error>> {
+        if !enabled {
+            return Ok(None);
+        }
+
+        let mut instance_gamepads = Vec::with_capacity(instances.len());
+        let mut has_gamepads = false;
+
+        for (instance_index, instance) in instances.iter().enumerate() {
+            let mut gamepads = Vec::new();
+
+            for &device_index in &instance.devices {
+                let device_info = input_devices.get(device_index).ok_or_else(|| {
+                    format!(
+                        "Instance {} references invalid input device index {}",
+                        instance_index + 1,
+                        device_index
+                    )
+                })?;
+
+                if device_info.device_type != DeviceType::Gamepad {
+                    continue;
+                }
+
+                has_gamepads = true;
+
+                let virtual_gamepad =
+                    create_virtual_gamepad(&device_info.path, instance_index, gamepads.len())?;
+
+                println!(
+                    "[partydeck] Created virtual gamepad for instance {}: {}",
+                    instance_index + 1,
+                    virtual_gamepad.path
+                );
+
+                gamepads.push(virtual_gamepad);
+            }
+
+            instance_gamepads.push(gamepads);
+        }
+
+        if !has_gamepads {
+            println!(
+                "[partydeck] Virtual gamepad mode is enabled, \
+                 but no gamepads are assigned"
+            );
+
+            return Ok(None);
+        }
+
+        Ok(Some(Self { instance_gamepads }))
+    }
+
+    pub fn gamepads_for_instance(&self, instance_index: usize) -> impl Iterator<Item = &str> {
+        self.instance_gamepads
+            .get(instance_index)
+            .into_iter()
+            .flatten()
+            .map(|gamepad| gamepad.path.as_str())
+    }
+}
+
+fn create_virtual_gamepad(
+    physical_path: &str,
+    instance_index: usize,
+    gamepad_index: usize,
+) -> Result<VirtualGamepad, Box<dyn std::error::Error>> {
+    let physical = Device::open(physical_path)?;
+
+    let name = format!(
+        "{} {}-{}",
+        VIRTUAL_GAMEPAD_NAME_PREFIX,
+        instance_index + 1,
+        gamepad_index + 1
+    );
+
+    let mut builder = VirtualDevice::builder()?
+        .name(&name)
+        .input_id(physical.input_id());
+
+    if let Some(keys) = physical.supported_keys() {
+        builder = builder.with_keys(keys)?;
+    }
+
+    for (axis, abs_info) in physical.get_absinfo()? {
+        let setup = UinputAbsSetup::new(axis, abs_info);
+        builder = builder.with_absolute_axis(&setup)?;
+    }
+
+    let mut virtual_device = builder.build()?;
+    let virtual_path = find_event_path(&mut virtual_device)?;
+
+    let physical_path = physical_path.to_owned();
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = Arc::clone(&stop);
+
+    let thread = thread::spawn(move || {
+        relay_loop(physical_path, physical, virtual_device, thread_stop);
+    });
+
+    Ok(VirtualGamepad {
+        path: virtual_path,
+        stop,
+        thread: Some(thread),
+    })
+}
+
+fn relay_loop(
+    physical_path: String,
+    physical: Device,
+    mut virtual_device: VirtualDevice,
+    stop: Arc<AtomicBool>,
+) {
+    if let Err(error) = physical.set_nonblocking(true) {
+        eprintln!(
+            "[partydeck] Failed to set gamepad {} to non-blocking mode: {}",
+            physical_path, error
+        );
+        return;
+    }
+
+    println!(
+        "[partydeck] Started virtual gamepad relay for {}",
+        physical_path
+    );
+
+    let mut physical_device = Some(physical);
+
+    while !stop.load(Ordering::Relaxed) {
+        if physical_device.is_none() {
+            match Device::open(&physical_path) {
+                Ok(device) => {
+                    if let Err(error) = device.set_nonblocking(true) {
+                        eprintln!(
+                            "[partydeck] Failed to reopen gamepad {}: {}",
+                            physical_path, error
+                        );
+
+                        thread::sleep(Duration::from_millis(500));
+                        continue;
+                    }
+
+                    println!(
+                        "[partydeck] Physical gamepad reconnected: {}",
+                        physical_path
+                    );
+
+                    physical_device = Some(device);
+                }
+
+                Err(_) => {
+                    thread::sleep(Duration::from_millis(500));
+                    continue;
+                }
+            }
+        }
+
+        let fetch_result = {
+            let Some(device) = physical_device.as_mut() else {
+                continue;
+            };
+
+            device.fetch_events().map(|events| {
+                events
+                    .filter(|event| event.event_type() != EventType::SYNCHRONIZATION)
+                    .collect::<Vec<InputEvent>>()
+            })
+        };
+
+        match fetch_result {
+            Ok(events) => {
+                if events.is_empty() {
+                    thread::sleep(Duration::from_millis(2));
+                    continue;
+                }
+
+                if let Err(error) = virtual_device.emit(&events) {
+                    eprintln!(
+                        "[partydeck] Failed to emit virtual gamepad events: {}",
+                        error
+                    );
+                }
+            }
+
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(2));
+            }
+
+            Err(error) => {
+                eprintln!(
+                    "[partydeck] Physical gamepad disconnected or failed ({}): {}",
+                    physical_path, error
+                );
+
+                physical_device = None;
+                thread::sleep(Duration::from_millis(500));
+            }
+        }
+    }
+
+    println!(
+        "[partydeck] Stopped virtual gamepad relay for {}",
+        physical_path
+    );
+}
+
+fn find_event_path(device: &mut VirtualDevice) -> Result<String, Box<dyn std::error::Error>> {
+    let paths: Vec<PathBuf> = device
+        .enumerate_dev_nodes_blocking()?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let path = paths
+        .into_iter()
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("event"))
+        })
+        .ok_or("Virtual gamepad event node was not created")?;
+
+    Ok(path.to_string_lossy().into_owned())
+}


### PR DESCRIPTION
## What this changes

Adds optional virtual gamepads backed by `uinput`.

When enabled, Partydeck creates a virtual controller for each physical controller and forwards input events to it. Game instances receive the virtual devices instead of the physical ones.

The main goal is to keep controller assignments stable when a physical controller disconnects and reconnects.

## Implementation notes

- Adds a `use_virtual_gamepads` option, disabled by default.
- Creates and manages virtual controllers through `uinput`.
- Forwards events from physical controllers to their virtual counterparts.
- Keeps the virtual device available while the physical controller is disconnected.
- Reconnects the physical controller to the same virtual device when possible.
- Exposes only the assigned virtual controllers inside each game instance.
- Filters Partydeck's own virtual devices from normal controller detection.

## Testing

Tested locally with multiple instances and controllers.

I checked:

- disconnecting and reconnecting controllers;
- keeping controller assignments after reconnecting;
- isolating controllers between instances;
- launching games with the option enabled and disabled.

This currently works on my setup, but testing with other controller models and Linux environments would be useful.
