### PR TITLE
Show each instance only its own input devices instead of masking others

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -9,6 +9,21 @@ use crate::paths::*;
 use crate::profiles::{create_profile, create_profile_gamesave};
 use crate::util::*;
 
+/// Legacy /dev/input/jsN nodes belonging to the same physical device as an evdev node.
+fn js_siblings(evdev_path: &str) -> Vec<String> {
+    let Some(name) = Path::new(evdev_path).file_name().and_then(|s| s.to_str()) else {
+        return Vec::new();
+    };
+    std::fs::read_dir(format!("/sys/class/input/{name}/device"))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| e.file_name().to_str().map(str::to_string))
+        .filter(|n| n.starts_with("js"))
+        .map(|n| format!("/dev/input/{n}"))
+        .collect()
+}
+
 pub fn setup_profiles(
     h: &Handler,
     instances: &Vec<Instance>,
@@ -239,16 +254,47 @@ pub fn launch_cmds(
         cmd.arg("--die-with-parent");
         cmd.args(["--dev-bind", "/", "/"]);
         cmd.args(["--tmpfs", "/tmp"]);
-        // Mask out any gamepads that aren't this player's
+
+        // Show this instance only the devices it should see, rather than hiding the ones it
+        // should not.
+        //
+        // Masking works on the devices that exist when bwrap starts. Anything that appears
+        // afterwards was never masked anywhere, so it is visible to EVERY instance at once.
+        // That is not an edge case with wireless pads: they power themselves off when idle,
+        // and waking one destroys its kernel device and creates a new one, usually on a
+        // different /dev/input/eventN. The player wakes their pad and starts driving all four
+        // games.
+        //
+        // It cannot be fixed by masking harder, because you cannot bind over a path that does
+        // not exist yet. The list has to be inverted.
+        //
+        // The visibility rules are unchanged: a device is bound in unless it is disabled, or
+        // it is a gamepad assigned to somebody else. A device that shows up later is now
+        // simply absent instead of shared.
+        cmd.args(["--tmpfs", "/dev/input"]);
         for (d, dev) in input_devices.iter().enumerate() {
             if !dev.enabled
                 || (!instance.devices.contains(&d) && dev.device_type == DeviceType::Gamepad)
             {
-                cmd.args(["--bind", "/dev/null", &dev.path]);
-                // Wine's winebus reads controllers via /dev/hidraw* when
-                // hidraw is exposed, so masking only the evdev node leaks
-                // input to every instance.
-                if h.enable_hidraw {
+                continue;
+            }
+            if Path::new(&dev.path).exists() {
+                cmd.args(["--dev-bind", &dev.path, &dev.path]);
+            }
+            // Legacy /dev/input/jsN nodes are a separate file for the same device. evdev is
+            // preferred by SDL2, but titles that open jsN would find nothing under a tmpfs.
+            for js in js_siblings(&dev.path) {
+                cmd.args(["--dev-bind", &js, &js]);
+            }
+        }
+        // hidraw is not under /dev/input, so it still has to be masked rather than omitted.
+        // Wine's winebus reads controllers through it when hidraw is exposed, and leaving it
+        // open leaks input to every instance.
+        if h.enable_hidraw {
+            for (d, dev) in input_devices.iter().enumerate() {
+                if !dev.enabled
+                    || (!instance.devices.contains(&d) && dev.device_type == DeviceType::Gamepad)
+                {
                     for hp in &dev.hidraw_paths {
                         cmd.args(["--bind", "/dev/null", hp]);
                     }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -255,22 +255,7 @@ pub fn launch_cmds(
         cmd.args(["--dev-bind", "/", "/"]);
         cmd.args(["--tmpfs", "/tmp"]);
 
-        // Show this instance only the devices it should see, rather than hiding the ones it
-        // should not.
-        //
-        // Masking works on the devices that exist when bwrap starts. Anything that appears
-        // afterwards was never masked anywhere, so it is visible to EVERY instance at once.
-        // That is not an edge case with wireless pads: they power themselves off when idle,
-        // and waking one destroys its kernel device and creates a new one, usually on a
-        // different /dev/input/eventN. The player wakes their pad and starts driving all four
-        // games.
-        //
-        // It cannot be fixed by masking harder, because you cannot bind over a path that does
-        // not exist yet. The list has to be inverted.
-        //
-        // The visibility rules are unchanged: a device is bound in unless it is disabled, or
-        // it is a gamepad assigned to somebody else. A device that shows up later is now
-        // simply absent instead of shared.
+        // Only expose this instance to the input devices specifically associated with it
         cmd.args(["--tmpfs", "/dev/input"]);
         for (d, dev) in input_devices.iter().enumerate() {
             if !dev.enabled
@@ -281,12 +266,12 @@ pub fn launch_cmds(
             if Path::new(&dev.path).exists() {
                 cmd.args(["--dev-bind", &dev.path, &dev.path]);
             }
-            // Legacy /dev/input/jsN nodes are a separate file for the same device. evdev is
-            // preferred by SDL2, but titles that open jsN would find nothing under a tmpfs.
+            // Also expose the device's js sibling for games that use the legacy Joystick API
             for js in js_siblings(&dev.path) {
                 cmd.args(["--dev-bind", &js, &js]);
             }
         }
+        
         // hidraw is not under /dev/input, so it still has to be masked rather than omitted.
         // Wine's winebus reads controllers through it when hidraw is exposed, and leaving it
         // open leaks input to every instance.


### PR DESCRIPTION
Follows on from something @davidawesome02-backup described in #200:

> because of how we are masking inputs into bwrap, any new controllers or those with new ids in /dev/input/XXX will be then accessible to ALL instances

This is a fix for that specific problem, with no virtual devices involved.

**The bug.** Masking can only act on devices that exist when bwrap starts. Anything that shows up afterwards was never masked in any instance, so every instance can read it. With wireless pads this happens constantly, because they power off when idle and waking one destroys the kernel device and creates a new one, usually on a different `eventN`. The player wakes their controller and starts driving all four games.

**Why it can't be patched in place.** There is no path to bind `/dev/null` over until the device exists, so no amount of extra masking closes it. The list has to be inverted.

**What changed.** `/dev/input` becomes a tmpfs and the devices that should be visible get bound back in. The rules for what is visible are deliberately identical: a device is bound unless it is disabled, or it is a gamepad belonging to another player. `jsN` nodes are bound next to their evdev node so anything using the legacy joystick API still finds them. hidraw sits outside `/dev/input` and is masked exactly as before.

**Testing.** Running daily on my setup, four players, Xbox 360 wireless receiver, three monitors, Orcs Must Die 3 and Core Keeper. Before this, a pad that woke up mid session controlled every instance. After it, it controls none until relaunch, which is not perfect but is a much better failure. I also checked with SDL inside a replica sandbox that a whitelisted pad still enumerates, both with and without udev reachable.

**Not tested:** SteamOS or Steam Deck, PS controllers or the hidraw path, and keyboard/mouse instances beyond confirming they still get their devices.

**Provenance,** since it came up on #176: written with AI assistance, directed and tested by me. I'd rather say so than have you spot it. Happy to walk through any of the reasoning, and happy for it to be taken as a bug report with a suggested patch if you'd rather write it yourselves.