### PR TITLE
Ignore phantom Unknown-N outputs with no display attached

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -100,11 +100,37 @@ pub fn get_x11_dpi_scale() -> f32 {
     1.0
 }
 
+/// Is this an output that no display is actually plugged into?
+///
+/// The kernel's simpledrm driver registers the EFI boot framebuffer as a DRM connector named
+/// `Unknown-N` (some drivers use `None-N`), and it reports as connected forever because there
+/// is no hardware behind it to say otherwise. Usually the real GPU driver evicts simpledrm
+/// during boot, but on setups where it survives, the compositor treats it as a real screen.
+/// It can even be handed the primary role, in which case it is sorted to the front here and
+/// becomes monitor 0, so instances assigned to it are placed on a display that does not exist
+/// and the windows simply never appear.
+fn is_phantom(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.starts_with("unknown") || n.starts_with("none-")
+}
+
 pub fn get_monitors_errorless() -> Vec<Monitor> {
     let mut monitors = Vec::new();
 
     if let Ok(ret_monitors) = get_monitors_x11() {
         monitors = ret_monitors;
+    }
+
+    // Only filter if a real monitor survives it, so a machine that genuinely has nothing else
+    // still gets a usable display rather than falling through to the 1920x1080 guess below.
+    if monitors.iter().any(|m| !is_phantom(m.name())) {
+        monitors.retain(|m| {
+            let keep = !is_phantom(m.name());
+            if !keep {
+                println!("[PARTYDECK] Ignoring phantom output '{}' (no display attached)", m.name());
+            }
+            keep
+        });
     }
 
     if monitors.len() == 0 { // Quick patch for those who have no x11 visable monitors, so we dont just panic.


### PR DESCRIPTION
Small one. On my machine PartyDeck offered a monitor that does not exist, and instances assigned to it rendered nowhere. No error, the windows just never showed up.

The culprit is `simpledrm`. The kernel registers the EFI boot framebuffer as a DRM connector called `Unknown-1`, and it reads as connected permanently because there is no hardware behind it to say otherwise. Usually the real GPU driver evicts simpledrm during boot, but it can survive. In my case that is because I run `nvidia_drm.fbdev=0`, which is needed to stop a boot hang on a machine doing GPU passthrough, but anything that keeps simpledrm around will do it.

```
$ kscreen-doctor -o
Output: 1 HDMI-A-1   enabled connected  1920x1080
Output: 2 DP-3       enabled connected  1920x1080
Output: 3 DP-2       enabled connected  1920x1080
Output: 4 Unknown-1  enabled connected  1024x768    <- nothing plugged in
```

It was also the primary output, which sorts it to the front in `get_monitors_x11`, so it became monitor 0 and shifted the numbering of every real screen by one.

The patch skips outputs named `Unknown-N` or `None-N`, and only when at least one real output survives, so a machine that genuinely has nothing else still gets a display rather than falling through to the 1920x1080 fallback below it.

Tested on three real monitors plus the phantom. Not tested on SteamOS, where I would not expect simpledrm to survive in the first place.

Provenance, as with my other PR: written with AI assistance, directed and tested by me.