### PR TITLE
Show elapsed time instead of claiming the operation timed out

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -50,6 +50,9 @@ pub struct PartyApp {
     pub handler_lite: Option<Handler>,
 
     pub loading_msg: Option<String>,
+    /// The message a task started with, kept so the elapsed time can be appended without
+    /// compounding it onto itself every frame.
+    pub loading_base_msg: Option<String>,
     pub loading_since: Option<std::time::Instant>,
     #[allow(dead_code)]
     pub task: Option<std::thread::JoinHandle<()>>,
@@ -91,6 +94,7 @@ impl PartyApp {
             handler_lite,
             profiles: scan_profiles(false),
             loading_msg: None,
+            loading_base_msg: None,
             loading_since: None,
             task: None,
         };
@@ -172,14 +176,21 @@ impl eframe::App for PartyApp {
                 let _ = handle.join();
                 self.loading_since = None;
                 self.loading_msg = None;
+                self.loading_base_msg = None;
             } else {
                 self.task = Some(handle);
             }
         }
         if let Some(start) = self.loading_since {
-            if start.elapsed() > std::time::Duration::from_secs(60) {
-                // Give up waiting after one minute
-                self.loading_msg = Some("Operation timed out".to_string());
+            // Show how long this has been going rather than claiming it failed. Nothing is
+            // actually abandoned here, the task keeps running either way, so the old
+            // "Operation timed out" text was reporting a failure that had not happened.
+            // A large game copying or a cold Proton prefix build passes a minute easily.
+            let secs = start.elapsed().as_secs();
+            if secs > 20 {
+                if let Some(base) = &self.loading_base_msg {
+                    self.loading_msg = Some(format!("{base} ({secs}s)"));
+                }
             }
         }
         if let Some(msg) = &self.loading_msg {
@@ -212,6 +223,7 @@ impl PartyApp {
         F: FnOnce() + Send + 'static,
     {
         self.loading_msg = Some(msg.to_string());
+        self.loading_base_msg = Some(msg.to_string());
         self.loading_since = Some(std::time::Instant::now());
         self.task = Some(std::thread::spawn(f));
     }


### PR DESCRIPTION
The loading overlay switches to "Operation timed out" after 60 seconds, but nothing is actually abandoned. `self.task` keeps running and finishes normally, and the overlay clears when it does. So the message reports a failure that has not happened.

It is not hard to hit. Copying a large game into the instance directories, or building a cold Proton prefix, goes past a minute without anything being wrong. What you get is a box telling you it failed while it is quietly still working, and no way to tell whether waiting is pointless.

This appends the elapsed seconds to whatever message the task started with instead, and only after 20 seconds so short operations stay quiet:

```
Copying game files (43s)
```

The starting message is kept in a new `loading_base_msg` field, because `loading_msg` is rewritten every frame and formatting into it directly compounds the count onto itself.

If you would rather have a real timeout that actually cancels the task, I am happy to look at that instead. It is a bigger change though, since the task would need to be cancellable, and I did not want to assume that is wanted.

Provenance, as with my other PRs: written with AI assistance, directed and tested by me.